### PR TITLE
INT-3852 - missing account handling

### DIFF
--- a/src/steps/roles/index.ts
+++ b/src/steps/roles/index.ts
@@ -30,10 +30,20 @@ export async function fetchRoles({
 
 export async function buildAccountRoleRelationships({
   jobState,
+  logger,
 }: IntegrationStepExecutionContext<IntegrationConfig>) {
   const accountEntity = (await jobState.getData(
     ACCOUNT_ENTITY_DATA_KEY,
   )) as Entity;
+
+  if (!accountEntity) {
+    logger.publishEvent({
+      name: 'missing_account_entity',
+      description:
+        'Could not find account entity: please ensure that entered email address is correct.',
+    });
+    return;
+  }
 
   await jobState.iterateEntities(
     { _type: Entities.ROLE._type },

--- a/src/steps/users/index.ts
+++ b/src/steps/users/index.ts
@@ -31,10 +31,20 @@ export async function fetchUsers({
 
 export async function buildAccountUserRelationships({
   jobState,
+  logger,
 }: IntegrationStepExecutionContext<IntegrationConfig>) {
   const accountEntity = (await jobState.getData(
     ACCOUNT_ENTITY_DATA_KEY,
   )) as Entity;
+
+  if (!accountEntity) {
+    logger.publishEvent({
+      name: 'missing_account_entity',
+      description:
+        'Could not find account entity: please ensure that entered email address is correct.',
+    });
+    return;
+  }
 
   await jobState.iterateEntities(
     { _type: Entities.USER._type },


### PR DESCRIPTION
As described in the latest response in the Jira ticket we currently believe this is happening due to misspelled email .env value. When we did that on purpose, the integration failed in the same ways.

This PR slightly changes the code to check if the account entity is found and if not reminds the customers to recheck that.

The account entity is currently fetched via an outdated V1 endpoint (there was no way to fetch that data using their new API version) so we could improve/change how the account root node is built which could even eliminate the email value needing to be passed as the env.