### PR TITLE
NO-TICKET - Add more detailed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added more details to the error (including the `err` object as `cause`) which
+  helps when `err` doesn't contain `code` or `body` property.
+
 ## 2.1.0 - 2023-01-05
 
 ### Added

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,6 +76,7 @@ export class APIClient {
           endpoint: fnName,
           status: err.code,
           statusText: err.body,
+          cause: err,
         });
       }
     } while (totalCount > processed);


### PR DESCRIPTION
- Added more details to the error (including the `err` object as `cause`) which helps when `err` doesn't contain `code` or `body` property.
